### PR TITLE
Fix rsync permissions for dag-fetcher

### DIFF
--- a/1-airflow-webserver-deployment.yaml
+++ b/1-airflow-webserver-deployment.yaml
@@ -24,6 +24,18 @@ spec:
         runAsUser: 50000 # Airflow user ID
         fsGroup: 0
       initContainers:
+        - name: dag-fetcher
+          image: docker-local.artifactory.medimpact.com/com/medimpact/pdp/medgen-dags-python:0.0.6
+          imagePullPolicy: Always
+          command:
+            - "rsync"
+            - "-av"
+            - "--no-times"
+            - "/source_files/dags/"
+            - "/dags/"
+          volumeMounts:
+            - name: dags-volume
+              mountPath: "/dags"
         - name: wait-for-airflow-migrations
           image: docker-local.artifactory.medimpact.com/dockerhub/apache/airflow:slim-3.0.2
           imagePullPolicy: Always

--- a/10-scheduler-deployment.yaml
+++ b/10-scheduler-deployment.yaml
@@ -35,6 +35,7 @@ spec:
           command:
             - "rsync"
             - "-av"
+            - "--no-times"
             - "/source_files/dags/"
             - "/dags/"
           volumeMounts:

--- a/11-worker-deployment.yaml
+++ b/11-worker-deployment.yaml
@@ -35,6 +35,7 @@ spec:
           command:
             - "rsync"
             - "-av"
+            - "--no-times"
             - "/source_files/dags/"
             - "/dags/"
           volumeMounts:

--- a/9-airflow-dag-processor-deploy.yaml
+++ b/9-airflow-dag-processor-deploy.yaml
@@ -35,6 +35,7 @@ spec:
           command:
             - "rsync"
             - "-av"
+            - "--no-times"
             - "/source_files/dags/"
             - "/dags/"
           volumeMounts:


### PR DESCRIPTION
Update rsync command in dag-fetcher initContainers across all relevant deployments (webserver, scheduler, worker, dag-processor) to include the --no-times flag.

This prevents errors related to setting timestamps on volumes where the container user might not have adequate permissions, resolving the 'Operation not permitted (1)' rsync error.