### PR TITLE
Configure Airflow to use PostgreSQL backend

### DIFF
--- a/1-airflow-webserver-deployment.yaml
+++ b/1-airflow-webserver-deployment.yaml
@@ -45,8 +45,13 @@ spec:
             - "-c"
             - "exec airflow db check-migrations --migration-wait-timeout=60"
           env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
           resources:
             requests:
               cpu: "100m"
@@ -69,9 +74,16 @@ spec:
             - name: AIRFLOW_HOME
               value: /opt/airflow
             - name: AIRFLOW__CORE__EXECUTOR
-              value: CeleryExecutor # Matching the rest of the config
+              value: CeleryExecutor
+            - name: AIRFLOW__CORE__LOAD_EXAMPLES
+              value: "False"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: REDIS_PASSWORD # Add REDIS_PASSWORD env var
               valueFrom:
                 secretKeyRef:

--- a/10-scheduler-deployment.yaml
+++ b/10-scheduler-deployment.yaml
@@ -58,8 +58,13 @@ spec:
             - |
               exec /entrypoint airflow db check-migrations --migration-wait-timeout=60
           env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
       containers:
         - name: scheduler
           image: docker-local.artifactory.medimpact.com/dockerhub/apache/airflow:slim-3.0.2
@@ -88,8 +93,17 @@ spec:
               subPath: airflow_local_settings.py
               readOnly: true
           env:
+            - name: AIRFLOW__CORE__EXECUTOR
+              value: CeleryExecutor
+            - name: AIRFLOW__CORE__LOAD_EXAMPLES
+              value: "False"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/11-worker-deployment.yaml
+++ b/11-worker-deployment.yaml
@@ -58,8 +58,13 @@ spec:
             - |
               exec /entrypoint airflow db check-migrations --migration-wait-timeout=60
           env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
       containers:
         - name: worker
           image: docker-local.artifactory.medimpact.com/dockerhub/apache/airflow:slim-3.0.2
@@ -104,8 +109,17 @@ spec:
               subPath: airflow_local_settings.py
               readOnly: true
           env:
+            - name: AIRFLOW__CORE__EXECUTOR
+              value: CeleryExecutor
+            - name: AIRFLOW__CORE__LOAD_EXAMPLES
+              value: "False"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/3-airflow-postgres-secret.yaml
+++ b/3-airflow-postgres-secret.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airflow-postgres-creds
+  namespace: pdp-dev # Assuming the same namespace as other components
+type: Opaque
+data:
+  # The password "airflow_pass" needs to be base64 encoded.
+  # echo -n "airflow_pass" | base64
+  # airflow_pass -> YWlyZmxvd19wYXNz
+  postgres_password: YWlyZmxvd19wYXNz

--- a/8-airflow-api-server-deployment.yaml
+++ b/8-airflow-api-server-deployment.yaml
@@ -67,6 +67,15 @@ spec:
             # Dynamically created secret envs
             # Extra env          
             # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__EXECUTOR
+              value: CeleryExecutor
+            - name: AIRFLOW__CORE__LOAD_EXAMPLES
+              value: "False"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__CORE__FERNET_KEY
               valueFrom:
                 secretKeyRef:
@@ -76,11 +85,11 @@ spec:
               value: /opt/airflow
             # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
             - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: AIRFLOW_CONN_AIRFLOW_DB
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: AIRFLOW__WEBSERVER__SECRET_KEY
               valueFrom:
                 secretKeyRef:
@@ -160,6 +169,15 @@ spec:
             # Dynamically created secret envs
             # Extra env          
             # Hard Coded Airflow Envs
+            - name: AIRFLOW__CORE__EXECUTOR
+              value: CeleryExecutor
+            - name: AIRFLOW__CORE__LOAD_EXAMPLES
+              value: "False"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__CORE__FERNET_KEY
               valueFrom:
                 secretKeyRef:
@@ -169,11 +187,11 @@ spec:
               value: /opt/airflow
             # For Airflow <2.3, backward compatibility; moved to [database] in 2.3
             - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: AIRFLOW_CONN_AIRFLOW_DB
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/9-airflow-dag-processor-deploy.yaml
+++ b/9-airflow-dag-processor-deploy.yaml
@@ -58,8 +58,13 @@ spec:
             - |
               exec /entrypoint airflow db check-migrations --migration-wait-timeout=60
           env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
       containers:
         - name: dag-processor
           image: docker-local.artifactory.medimpact.com/dockerhub/apache/airflow:slim-3.0.2
@@ -89,8 +94,17 @@ spec:
               subPath: airflow_local_settings.py
               readOnly: true
           env:
+            - name: AIRFLOW__CORE__EXECUTOR
+              value: CeleryExecutor
+            - name: AIRFLOW__CORE__LOAD_EXAMPLES
+              value: "False"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: airflow-postgres-creds
+                  key: postgres_password
             - name: AIRFLOW__DATABASE__SQL_ALCHEMY_CONN
-              value: sqlite:////opt/airflow/airflow.db
+              value: postgresql+psycopg2://airflow_user:$(POSTGRES_PASSWORD)@devedb0-vip.medimpact.com:5432/pdp_airflow_db
             - name: REDIS_PASSWORD # Add REDIS_PASSWORD env var
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
- Updated Kubernetes deployments (Webserver, Scheduler, Worker, API Server, DAG Processor) to use PostgreSQL connection string.
- Added environment variables for CeleryExecutor and disabled example DAGs.
- Created a Kubernetes secret for PostgreSQL password and referenced it in deployments.
- Ensured initContainers also use the new database configuration.