### PR TITLE
Configure Airflow for PostgreSQL and add ServiceAccounts

### DIFF
--- a/0a-airflow-scheduler-sa.yaml
+++ b/0a-airflow-scheduler-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-scheduler
+  namespace: pdp-dev # Assuming the same namespace as other components

--- a/0b-airflow-worker-sa.yaml
+++ b/0b-airflow-worker-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: airflow-worker
+  namespace: pdp-dev # Assuming the same namespace as other components

--- a/0c-pdp-default-sa.yaml
+++ b/0c-pdp-default-sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pdp-default
+  namespace: pdp-dev # Assuming the same namespace as other components


### PR DESCRIPTION
- Updated Kubernetes deployments (Webserver, Scheduler, Worker, API Server, DAG Processor) to use PostgreSQL connection string.
- Added environment variables for CeleryExecutor and disabled example DAGs.
- Created a Kubernetes secret for PostgreSQL password and referenced it in deployments.
- Ensured initContainers also use the new database configuration.
- Added ServiceAccount manifests for airflow-scheduler, airflow-worker, and pdp-default to resolve deployment errors.